### PR TITLE
Revert "Bump golang from 1.17.4-alpine to 1.17.5-alpine"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.5-alpine AS base
+FROM golang:1.17.4-alpine AS base
 
 # Build golang healthcheck binary
 FROM base AS healthcheck


### PR DESCRIPTION
Reverts hibare/go-container-status#39